### PR TITLE
Fix AllureNonCriticalFailure

### DIFF
--- a/src/main/java/ru/sbtqa/tag/allurehelper/AllureNonCriticalFailure.java
+++ b/src/main/java/ru/sbtqa/tag/allurehelper/AllureNonCriticalFailure.java
@@ -1,7 +1,10 @@
 package ru.sbtqa.tag.allurehelper;
 
 import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.events.StepCanceledEvent;
 import ru.yandex.qatools.allure.events.StepFailureEvent;
+import ru.yandex.qatools.allure.events.TestCaseFailureEvent;
+import ru.yandex.qatools.allure.events.TestCasePendingEvent;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +24,7 @@ public class AllureNonCriticalFailure {
      * @param throvv - throw stack trace
      */
     public static void fire(Throwable throvv) {
-        Allure.LIFECYCLE.fire(new StepFailureEvent().withThrowable(throvv));
+        Allure.LIFECYCLE.fire(new StepBrokenEvent());
         Allure.LIFECYCLE.fire(new TestCaseBrokenEvent().withThrowable(throvv));
     }
 

--- a/src/main/java/ru/sbtqa/tag/allurehelper/AllureNonCriticalFailure.java
+++ b/src/main/java/ru/sbtqa/tag/allurehelper/AllureNonCriticalFailure.java
@@ -1,5 +1,8 @@
 package ru.sbtqa.tag.allurehelper;
 
+import ru.yandex.qatools.allure.Allure;
+import ru.yandex.qatools.allure.events.StepFailureEvent;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,7 +21,8 @@ public class AllureNonCriticalFailure {
      * @param throvv - throw stack trace
      */
     public static void fire(Throwable throvv) {
-        FAILURES_MAP.put(Thread.currentThread(), throvv);
+        Allure.LIFECYCLE.fire(new StepFailureEvent().withThrowable(throvv));
+        Allure.LIFECYCLE.fire(new TestCaseBrokenEvent().withThrowable(throvv));
     }
 
     /**

--- a/src/main/java/ru/sbtqa/tag/allurehelper/StepBrokenEvent.java
+++ b/src/main/java/ru/sbtqa/tag/allurehelper/StepBrokenEvent.java
@@ -1,0 +1,21 @@
+package ru.sbtqa.tag.allurehelper;
+
+import ru.yandex.qatools.allure.events.AbstractStepFailureEvent;
+import ru.yandex.qatools.allure.model.Status;
+import ru.yandex.qatools.allure.model.Step;
+
+/**
+ * Using to mark current step as broken
+ */
+public class StepBrokenEvent extends AbstractStepFailureEvent {
+
+    /**
+     * Change step status to {@link ru.yandex.qatools.allure.model.Status#BROKEN}
+     *
+     * @param step which will be changed
+     */
+    @Override
+    public void process(Step step) {
+        step.setStatus(Status.BROKEN);
+    }
+}

--- a/src/main/java/ru/sbtqa/tag/allurehelper/TestCaseBrokenEvent.java
+++ b/src/main/java/ru/sbtqa/tag/allurehelper/TestCaseBrokenEvent.java
@@ -1,0 +1,45 @@
+package ru.sbtqa.tag.allurehelper;
+
+import ru.yandex.qatools.allure.events.TestCaseStatusChangeEvent;
+import ru.yandex.qatools.allure.model.Status;
+
+/**
+ * Using to change testCase status to BROKEN
+ *
+ * @see TestCaseStatusChangeEvent
+ */
+public class TestCaseBrokenEvent extends TestCaseStatusChangeEvent {
+
+    private String message = "Test broken with unknown reason";
+
+    /**
+     * Returns the status BROKEN
+     *
+     * @return the status
+     */
+    @Override
+    protected Status getStatus() {
+        return Status.BROKEN;
+    }
+
+    /**
+     * Returns default message
+     *
+     * @return default message
+     */
+    @Override
+    protected String getMessage() {
+        return message;
+    }
+
+    /**
+     * Sets throwable
+     *
+     * @param value to set
+     * @return modified instance
+     */
+    public TestCaseBrokenEvent withThrowable(Throwable value) {
+        setThrowable(value);
+        return this;
+    }
+}

--- a/src/main/java/ru/sbtqa/tag/allurehelper/TestCaseBrokenEvent.java
+++ b/src/main/java/ru/sbtqa/tag/allurehelper/TestCaseBrokenEvent.java
@@ -33,6 +33,15 @@ public class TestCaseBrokenEvent extends TestCaseStatusChangeEvent {
     }
 
     /**
+     * Sets the default message
+     *
+     * @param message to set
+     */
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    /**
      * Sets throwable
      *
      * @param value to set


### PR DESCRIPTION
Fix AllureNonCriticalFailure
Create class TestCaseBrokenEvent because we used AutotestError and need get status "BROKEN" in Allure report